### PR TITLE
fix: use last business day in baostock query to handle non-trading days

### DIFF
--- a/src/data_collection/fetch_baostock_data.py
+++ b/src/data_collection/fetch_baostock_data.py
@@ -87,7 +87,10 @@ class DataManager:
         print("Loading A-Shares stock list")
         self._login_baostock()
         self._load_all_a_shares_base()
-        qry = bs.query_all_stock(day=str(datetime.date.today()))
+        # baostock returns empty results on non-trading days (weekends/holidays).
+        # Use the most recent business day to avoid ValueError on data reshaping.
+        last_bday = pd.bdate_range(end=datetime.date.today(), periods=1)[0]
+        qry = bs.query_all_stock(day=last_bday.strftime('%Y-%m-%d'))
         stocks = {code for code in self._result_to_data_frame(qry)["code"]
                   if code.startswith("sh") or code.startswith("sz")}
         self._all_a_shares += ["sh.000903", "sh.000300", "sh.000905", "sh.000852"]


### PR DESCRIPTION
## Problem

`_load_all_a_shares` calls `bs.query_all_stock(day=str(datetime.date.today()))`. On weekends and public holidays, baostock returns an empty result set, causing downstream code to fail with:

```
ValueError: cannot reshape array of size 0 into shape (6,0)
```

Fixes #8.

## Fix

Replace `datetime.date.today()` with the most recent business day via `pd.bdate_range`:

```python
# Before
qry = bs.query_all_stock(day=str(datetime.date.today()))

# After
last_bday = pd.bdate_range(end=datetime.date.today(), periods=1)[0]
qry = bs.query_all_stock(day=last_bday.strftime('%Y-%m-%d'))
```

This ensures the query always hits a valid trading date regardless of when data collection is run.

## Notes

- `pd.bdate_range` is already available since `pandas` is a core dependency
- No behaviour change on trading days