### PR TITLE
fix: correct Sharpe ratio inflation from overlapping return windows

### DIFF
--- a/run_adaptive_combination.py
+++ b/run_adaptive_combination.py
@@ -259,9 +259,14 @@ def get_tensor_metrics(x, y, risk_free_rate=0.0):
     ret_s_mean = (ret_s).mean().item()
     ret_s_std = (ret_s).std().item() if (ret_s).std().item() > 1e-6 else 1.0
 
-    # Calculate Sharpe Ratio and Maximum Drawdown for ret series
-    ret_sharpe = batch_sharpe_ratio(ret_s, risk_free_rate).item()
-    ret_mdd = batch_max_drawdown(ret_s).item()
+    # Calculate Sharpe Ratio and Maximum Drawdown using non-overlapping returns.
+    # ret_s is derived from label_days-day forward returns, so consecutive entries
+    # are highly autocorrelated (overlapping windows). Using them directly deflates
+    # variance by ~label_days and inflates Sharpe by ~sqrt(label_days).
+    # Sampling every label_days steps yields non-overlapping, independent observations.
+    ret_s_nonoverlap = ret_s[::args.label_days]
+    ret_sharpe = batch_sharpe_ratio(ret_s_nonoverlap, risk_free_rate).item()
+    ret_mdd = batch_max_drawdown(ret_s_nonoverlap).item()
 
     result = dict(
         ic=ic_s_mean,


### PR DESCRIPTION
## Problem

As reported in #5, the Sharpe ratio reported by `get_tensor_metrics` in `run_adaptive_combination.py` is inflated by approximately `√label_days` (≈ 4.47× for the default `label_days=20`).

**Root cause:** `ret_s` is computed from `label_days`-day forward returns, so consecutive values overlap across `label_days - 1` days. Dividing by `label_days` preserves the mean but artificially compresses variance:

$$\text{Var}(X_t) \approx \frac{\sigma^2}{N}, \quad \text{so} \quad SR_{\text{reported}} = \sqrt{N} \cdot SR_{\text{true}}$$

## Fix

Sample every `label_days` steps before computing Sharpe and MDD to obtain non-overlapping, approximately independent return observations:

```python
ret_s_nonoverlap = ret_s[::args.label_days]
ret_sharpe = batch_sharpe_ratio(ret_s_nonoverlap, risk_free_rate).item()
ret_mdd    = batch_max_drawdown(ret_s_nonoverlap).item()
```

The full overlapping `ret_s` is kept for saving and all other downstream uses — only the Sharpe/MDD metric values are corrected.

Closes #5.