### PR TITLE
docs: clarify that entropy sign in EntropyTBGFlowNet.loss() is correct

### DIFF
--- a/src/alpha_gfn/gflownet.py
+++ b/src/alpha_gfn/gflownet.py
@@ -96,6 +96,10 @@ class EntropyTBGFlowNet(TBGFlowNet):
         _, _, scores, entropy_term = self.get_trajectories_scores(
             trajectories, recalculate_all_logprobs=recalculate_all_logprobs
         )
+        # Subtracting entropy_term (which is positive when entropy_coef > 0) from the
+        # TB loss means minimising `loss` simultaneously minimises the TB objective AND
+        # maximises policy entropy — encouraging diverse exploration. The sign is correct.
+        # See Issue #2 for discussion.
         loss = (scores + self.logZ).pow(2).mean() - entropy_term.mean()
         if torch.isnan(loss):
             # set inf


### PR DESCRIPTION
## Context

Issue #2 asked whether the entropy sign in `EntropyTBGFlowNet.loss()` is correct.

## Answer

The sign is correct. The current implementation:

```python
loss = (scores + self.logZ).pow(2).mean() - entropy_term.mean()
```

`entropy_term` is **positive** (it is `entropy_coef × H(π)`, where `H ≥ 0` and `entropy_coef > 0`).

Subtracting a positive value from the TB loss means the gradient step that minimises `loss` simultaneously:
1. Minimises the trajectory balance objective (flow conservation)
2. **Maximises** policy entropy — exactly the desired diversity-promoting behaviour

This PR adds an inline comment to make this clear for future readers.

Closes #2.